### PR TITLE
Add persistent volume for api and api-worker

### DIFF
--- a/helm/circles-infra-suite/templates/api-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-deployment.yaml
@@ -304,6 +304,9 @@ spec:
                 configMapKeyRef:
                   key: postgres_user
                   name: env
+          volumeMounts:
+            - mountPath: /usr/src/app/edges-data
+              name: data
           image: registry.digitalocean.com/circles-registry/api:v1.3.0
           imagePullPolicy: ""
           name: circles-api
@@ -312,5 +315,8 @@ spec:
           resources: {}
       restartPolicy: Always
       serviceAccountName: ""
-      volumes: null
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: api-data
 status: {}

--- a/helm/circles-infra-suite/templates/api-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-deployment.yaml
@@ -307,7 +307,7 @@ spec:
           volumeMounts:
             - mountPath: /usr/src/app/edges-data
               name: data
-          image: registry.digitalocean.com/circles-registry/api:v1.3.0
+          image: registry.digitalocean.com/circles-registry/api:v1.3.1
           imagePullPolicy: ""
           name: circles-api
           ports:

--- a/helm/circles-infra-suite/templates/api-persistentvolumeclaim.yaml
+++ b/helm/circles-infra-suite/templates/api-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: api
+  name: api-data
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 500Mi
+  storageClassName: nfs

--- a/helm/circles-infra-suite/templates/api-worker-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-worker-deployment.yaml
@@ -304,7 +304,7 @@ spec:
           volumeMounts:
             - mountPath: /usr/src/app/edges-data
               name: data
-          image: registry.digitalocean.com/circles-registry/api:v1.3.0
+          image: registry.digitalocean.com/circles-registry/api:v1.3.1
           imagePullPolicy: ""
           name: circles-api-worker
           ports:

--- a/helm/circles-infra-suite/templates/api-worker-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-worker-deployment.yaml
@@ -301,6 +301,9 @@ spec:
                 configMapKeyRef:
                   key: postgres_user
                   name: env
+          volumeMounts:
+            - mountPath: /usr/src/app/edges-data
+              name: data
           image: registry.digitalocean.com/circles-registry/api:v1.3.0
           imagePullPolicy: ""
           name: circles-api-worker
@@ -309,5 +312,8 @@ spec:
           resources: {}
       restartPolicy: Always
       serviceAccountName: ""
-      volumes: null
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: api-data
 status: {}


### PR DESCRIPTION
- [x] Install nfs server on Kubernetes via helm: https://www.digitalocean.com/community/tutorials/how-to-set-up-readwritemany-rwx-persistent-volumes-with-nfs-on-digitalocean-kubernetes
- [x] Add persistent volume claim and mount volume in `api` and `api-worker`
- [x] Use latest circles-api version with improved paths (https://github.com/CirclesUBI/circles-api/pull/58)

Closes: https://github.com/CirclesUBI/circles-iac/issues/5