### PR TITLE
Add configuration for api v1.5.0

### DIFF
--- a/helm/circles-infra-suite/templates/api-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-deployment.yaml
@@ -52,6 +52,14 @@ spec:
                   key: RELAY_SERVICE_ENDPOINT
                   name: env
 
+            # Redis service
+            # ~~~~~~~~~~~~~
+            - name: REDIS_URL
+              valueFrom:
+                configMapKeyRef:
+                  key: REDIS_URL
+                  name: env
+
             # "The Graph" Configuration
             # ~~~~~~~~~~~~~~~~~~~~~~~~~
             - name: GRAPH_NODE_ENDPOINT
@@ -144,4 +152,11 @@ spec:
               valueFrom:
                 configMapKeyRef:
                   key: POSTGRES_DATABASE_API
+                  name: env
+            # Indexed Data Configuration
+            # ~~~~~~~~~~~~~~~~~~~~
+            - name: DATABASE_SOURCE
+              valueFrom:
+                configMapKeyRef:
+                  key: DATABASE_SOURCE
                   name: env

--- a/helm/circles-infra-suite/templates/api-worker-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-worker-deployment.yaml
@@ -159,3 +159,10 @@ spec:
                 configMapKeyRef:
                   key: POSTGRES_DATABASE_API
                   name: env
+            # Indexed Data Configuration
+            # ~~~~~~~~~~~~~~~~~~~~
+            - name: DATABASE_SOURCE
+              valueFrom:
+                configMapKeyRef:
+                  key: DATABASE_SOURCE
+                  name: env

--- a/helm/circles-infra-suite/templates/configmap.yaml
+++ b/helm/circles-infra-suite/templates/configmap.yaml
@@ -38,15 +38,11 @@ data:
   # ~~~~~~~~~~~~~~~~~~~~
   POSTGRES_DATABASE_API: api
   POSTGRES_DATABASE_RELAYER: relayer
-<<<<<<< update-api-1.5.0
 
   # Indexed Data Configuration
   # ~~~~~~~~~~~~~~~~~~~~
   DATABASE_SOURCE: graph
 
-=======
-  
->>>>>>> main
   # Relayer Addresses
   # ~~~~~~~~~~~~~~~~~
   SAFE_FUNDER_ADDRESS: {{.Values.relayer.funderAddress}}

--- a/helm/circles-infra-suite/templates/configmap.yaml
+++ b/helm/circles-infra-suite/templates/configmap.yaml
@@ -39,6 +39,10 @@ data:
   POSTGRES_DATABASE_API: api
   POSTGRES_DATABASE_RELAYER: relayer
 
+  # Indexed Data Configuration
+  # ~~~~~~~~~~~~~~~~~~~~
+  DATABASE_SOURCE: graph
+
   # Relayer Addresses
   # ~~~~~~~~~~~~~~~~~
   SAFE_FUNDER_ADDRESS: {{.Values.relayer.funderAddress}}

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -8,7 +8,7 @@ host: circles.garden
 # ~~~~~~~~~~~~~~~~~~~
 apiService:
   # Docker tag
-  imageTag: v1.3.22
+  imageTag: v1.5.0
 
   # Ingress
   host: api.circles.garden

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -8,7 +8,7 @@ host: circles.garden
 # ~~~~~~~~~~~~~~~~~~~
 apiService:
   # Docker tag
-  imageTag: v1.5.0
+  imageTag: v1.6.0
 
   # Ingress
   host: api.circles.garden


### PR DESCRIPTION
We can use this for testing, although the load is high on the worker and the pod gets evicted.
Reason: `The node was low on resource: memory. Container circles-api was using 2281552Ki, which exceeds its request of 0.`