### PR TITLE
Add the xbge berlin domain to cors whitelist

### DIFF
--- a/helm/circles-infra-suite/values.yaml
+++ b/helm/circles-infra-suite/values.yaml
@@ -57,4 +57,4 @@ aws:
 
 # CORS 
 # ~~~~~~~~~~~~~~~~~~~~
-circlesPinkURLs: https://circles.pink,https://expedition-grundeinkommen.de,https://next.expedition-grundeinkommen.de
+circlesPinkURLs: https://circles.pink,https://expedition-grundeinkommen.de,https://next.expedition-grundeinkommen.de,https://www.volksentscheid-grundeinkommen.de


### PR DESCRIPTION
The Berlin project has it's own domain, so it would be awesome, if it could be whitelisted too!