### PR TITLE
Insufficient fund error in STG envinroment

### DIFF
--- a/helm/circles-infra-suite/values-staging.yaml
+++ b/helm/circles-infra-suite/values-staging.yaml
@@ -17,7 +17,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker image tag
-  imageTag: v4.1.13
+  imageTag: v4.1.15-pre-ca2abd4
 
   # Ingress
   host: relay.staging.circles.garden


### PR DESCRIPTION
This version is currently deployed in staging, but it's not working.
Logs:
```
2022-09-08 15:32:19,546 [INFO] [MainProcess] Safe.build_safe_create2_tx params: 0x8b4404DE0CaECE4b966a9959f134f0eFDa636156 0x0F9f9C38E53674EF7a29A1DE38EAbF34e1DCB81C 61155221391700 ['0xCBFC380f622411EcD95B64EF0A79379ECF3F4954'] 1 1000000000 0x0000000000000000000000000000000000000000 0x691b74E59b7D65572DFF5543e5A0e23c2F32049a 0x0000000000000000000000000000000000000003 1.0 None
2022-09-08 15:32:20,159 [WARNING] [MainProcess] https://relay.staging.circles.garden/api/v3/safes/predict/ - Exception: ValueError: {'code': -32000, 'message': 'insufficient funds for transfer: address 0xfffffffffffffffffffffffffffffffffffffffe'} - Data received {'salt_nonce': 61155221391700, 'owners': ['0xCBFC380f622411EcD95B64EF0A79379ECF3F4954'], 'threshold': 1}
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
  File "/safe-relay-service/safe_relay_service/relay/views_v3.py", line 65, in post
    safe_prediction = safe_creation_service.predict_address(salt_nonce, owners, threshold, payment_token)
  File "/safe-relay-service/safe_relay_service/relay/services/safe_creation_service.py", line 205, in predict_address
    safe_creation_tx = Safe.build_safe_create2_tx(self.ethereum_client,
  File "/usr/local/lib/python3.9/site-packages/gnosis/safe/safe.py", line 326, in build_safe_create2_tx
    safe_creation_tx = SafeCreate2TxBuilder(w3=ethereum_client.w3,
  File "/usr/local/lib/python3.9/site-packages/gnosis/safe/safe_create2_tx.py", line 100, in build
    estimated_gas: int = self._estimate_gas(safe_setup_data,
  File "/usr/local/lib/python3.9/site-packages/gnosis/safe/safe_create2_tx.py", line 186, in _estimate_gas
    gas += self.w3.eth.estimate_gas({'to': payment_receiver, 'value': Wei(payment)})
  File "/usr/local/lib/python3.9/site-packages/web3/eth.py", line 735, in estimate_gas
    return self._estimate_gas(transaction, block_identifier)
  File "/usr/local/lib/python3.9/site-packages/web3/module.py", line 57, in caller
    result = w3.manager.request_blocking(method_str,
  File "/usr/local/lib/python3.9/site-packages/web3/manager.py", line 187, in request_blocking
    return self.formatted_response(response,
  File "/usr/local/lib/python3.9/site-packages/web3/manager.py", line 168, in formatted_response
    raise ValueError(response["error"])
ValueError: {'code': -32000, 'message': 'insufficient funds for transfer: address 0xfffffffffffffffffffffffffffffffffffffffe'}
2022-09-08 15:32:20,162 [ERROR] [MainProcess] Internal Server Error: /api/v3/safes/predict/
2022-09-08 15:32:20,162 [ERROR] [MainProcess] Internal Server Error: /api/v3/safes/predict/
```