### PR TITLE
Set new env var for api: TRANSFER_STEPS_TIMEOUT

### DIFF
--- a/helm/circles-infra-suite/templates/api-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-deployment.yaml
@@ -164,3 +164,10 @@ spec:
                 configMapKeyRef:
                   key: DATABASE_SOURCE
                   name: env
+            # Api timeout Configuration
+            # ~~~~~~~~~~~~~~~~~~~~
+            - name: TRANSFER_STEPS_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  key: TRANSFER_STEPS_TIMEOUT
+                  name: env

--- a/helm/circles-infra-suite/templates/api-worker-deployment.yaml
+++ b/helm/circles-infra-suite/templates/api-worker-deployment.yaml
@@ -171,3 +171,10 @@ spec:
                 configMapKeyRef:
                   key: DATABASE_SOURCE
                   name: env
+            # Api timeout Configuration
+            # ~~~~~~~~~~~~~~~~~~~~
+            - name: TRANSFER_STEPS_TIMEOUT
+              valueFrom:
+                configMapKeyRef:
+                  key: TRANSFER_STEPS_TIMEOUT
+                  name: env

--- a/helm/circles-infra-suite/templates/configmap.yaml
+++ b/helm/circles-infra-suite/templates/configmap.yaml
@@ -44,7 +44,7 @@ data:
 
   # Api timeout Configuration (in ms)
   # ~~~~~~~~~~~~~~~~~~~~
-  TRANSFER_STEPS_TIMEOUT: 150000
+  TRANSFER_STEPS_TIMEOUT: {{.Values.apiService.transferStepsTimeout}}
 
   # Relayer Addresses
   # ~~~~~~~~~~~~~~~~~

--- a/helm/circles-infra-suite/templates/configmap.yaml
+++ b/helm/circles-infra-suite/templates/configmap.yaml
@@ -42,6 +42,10 @@ data:
   # ~~~~~~~~~~~~~~~~~~~~
   DATABASE_SOURCE: graph
 
+  # Api timeout Configuration (in ms)
+  # ~~~~~~~~~~~~~~~~~~~~
+  TRANSFER_STEPS_TIMEOUT: 150000
+
   # Relayer Addresses
   # ~~~~~~~~~~~~~~~~~
   SAFE_FUNDER_ADDRESS: {{.Values.relayer.funderAddress}}

--- a/helm/circles-infra-suite/templates/configmap.yaml
+++ b/helm/circles-infra-suite/templates/configmap.yaml
@@ -44,7 +44,7 @@ data:
 
   # Api timeout Configuration (in ms)
   # ~~~~~~~~~~~~~~~~~~~~
-  TRANSFER_STEPS_TIMEOUT: {{.Values.apiService.transferStepsTimeout}}
+  TRANSFER_STEPS_TIMEOUT: '150000'
 
   # Relayer Addresses
   # ~~~~~~~~~~~~~~~~~

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -17,7 +17,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-pre-1ecf427
+  imageTag: v5.0.2-pre-544cf05
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -13,14 +13,11 @@ apiService:
   # Ingress
   host: api.circles.garden
 
-  # Timeout in ms
-  transferStepsTimeout: 150000
-
 # circles-relayer Service
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-1-g9f06047
+  imageTag: v5.0.2-pre-3a13120
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -20,7 +20,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-1-g0ec746a
+  imageTag: v5.0.2-1-g9f06047
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -17,7 +17,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-pre-3a13120
+  imageTag: v5.0.2-pre-1ecf427
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -17,7 +17,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-pre-c464245
+  imageTag: v5.0.2-pre-gb3b5c0c
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -17,7 +17,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-pre-gb3b5c0c
+  imageTag: v5.0.2-pre-g8ac7fc4
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -17,7 +17,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker tag
-  imageTag: v5.0.2-pre-544cf05
+  imageTag: v5.0.2-pre-c464245
   # Ingress
   host: relay.circles.garden
 

--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -13,6 +13,9 @@ apiService:
   # Ingress
   host: api.circles.garden
 
+  # Timeout in ms
+  transferStepsTimeout: 150000
+
 # circles-relayer Service
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:

--- a/helm/circles-infra-suite/values-staging.yaml
+++ b/helm/circles-infra-suite/values-staging.yaml
@@ -20,7 +20,7 @@ apiService:
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:
   # Docker image tag
-  imageTag: v5.0.2-1-g03d86df
+  imageTag: v5.0.2-1-g9f06047
 
   # Ingress
   host: relay.staging.circles.garden

--- a/helm/circles-infra-suite/values-staging.yaml
+++ b/helm/circles-infra-suite/values-staging.yaml
@@ -13,6 +13,9 @@ apiService:
   # Ingress
   host: api.staging.circles.garden
 
+  # Timeout in ms
+  transferStepsTimeout: 150000
+
 # circles-relayer Service
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:

--- a/helm/circles-infra-suite/values.yaml
+++ b/helm/circles-infra-suite/values.yaml
@@ -27,6 +27,9 @@ apiService:
   volumeClaimName: api-data
   volumeMountPath: /usr/src/app/edges-data
 
+  # Timeout in ms
+  transferStepsTimeout: 150000
+
 # circles-relayer Service
 # ~~~~~~~~~~~~~~~~~~~~~~~
 relayerService:


### PR DESCRIPTION
We are setting this value lower (in milliseconds) than the nginx timeout value: https://github.com/CirclesUBI/circles-iac/blob/main/helm/circles-infra-suite/templates/ingress.yaml#L7

Here we also update to the last relayer testing version: https://github.com/CirclesUBI/safe-relay-service/pull/71