### PR TITLE
Update pathfinder url in prod

### DIFF
--- a/helm/circles-infra-suite/values-production.yaml
+++ b/helm/circles-infra-suite/values-production.yaml
@@ -61,4 +61,4 @@ relayer:
 # Pathfinder config
 # ~~~~~~~~~~~~~~~~~
 pathfinder:
-  endpoint: https://rpc.circlesubi.id/pathfinder
+  endpoint: https://pathfinder.circlesubi.id


### PR DESCRIPTION
The new pathfinder service endpoint relies on DNS round robin load balancing. If one of the host goes down, it's not isolated and 50% of the requests will still go to the host that's down. The new endpoint also isolates failed instances so that at max. a few requests would fail.

Closes https://github.com/CirclesUBI/circles-myxogastria/issues/702