### PR TITLE
fix nethermind/lighthouse installation

### DIFF
--- a/ansible/roles/rpc-node/files/lighthouse-prd.yaml
+++ b/ansible/roles/rpc-node/files/lighthouse-prd.yaml
@@ -1,6 +1,3 @@
-
-replicas: 1
-
 image:
   repository: sigp/lighthouse
   tag: v4.3.0

--- a/ansible/roles/rpc-node/files/lighthouse-prd.yaml
+++ b/ansible/roles/rpc-node/files/lighthouse-prd.yaml
@@ -1,22 +1,39 @@
 
-# -- Number of replicas
 replicas: 1
 
 image:
-  # -- Lighthouse container image repository
   repository: sigp/lighthouse
-  # -- Lighthouse container image tag
-  tag: v4.2.0
-  # -- Lighthouse container pull policy
+  tag: v4.3.0
   pullPolicy: IfNotPresent
 
-# -- Mode can be 'beacon','validator' or 'bootnode'
 mode: "beacon"
 
-# -- Extra args for the lighthouse container
-extraArgs:
-  - --network=gnosis
-  - --execution-endpoint=http://xdai-nethermind.xdai:8551
-  - --checkpoint-sync-url=https://checkpoint.gnosischain.com/
+checkpointSync:
+  enabled: true
+  url: "https://checkpoint.gnosischain.com/"
 
 jwt:
+
+defaultBeaconCommandTemplate: |
+  - sh
+  - -ac
+  - >
+    exec lighthouse
+    beacon_node
+    --network=gnosis
+    --execution-endpoint=http://xdai-nethermind.xdai:8551
+    --datadir=/data
+    --disable-upnp
+    --listen-address=0.0.0.0
+    --port={{ include "lighthouse.p2pPort" . }}
+    --discovery-port={{ include "lighthouse.p2pPort" . }}
+    --http
+    --http-address=0.0.0.0
+    --http-port={{ .Values.httpPort }}
+    --execution-jwt=/data/jwt.hex
+    --metrics
+    --metrics-address=0.0.0.0
+    --metrics-port={{ .Values.metricsPort }}
+  {{- if .Values.checkpointSync.enabled }}
+    --checkpoint-sync-url={{ tpl .Values.checkpointSync.url $ }}
+  {{- end }}

--- a/ansible/roles/rpc-node/files/nethermind-prd.yaml
+++ b/ansible/roles/rpc-node/files/nethermind-prd.yaml
@@ -1,12 +1,8 @@
 image:
-  # -- nethermind container image repository
   repository: nethermind/nethermind
-  # -- nethermind container image tag
-  tag: 1.20.0
-  # -- nethermind container pull policy
+  tag: 1.20.1
   pullPolicy: IfNotPresent
 
-# -- Extra args for the nethermind container
 extraArgs:
   - --config gnosis
   - --Init.MemoryHint 1500000000
@@ -16,25 +12,20 @@ extraArgs:
   - --Init.DiscoveryEnabled true
   - --Merge.Enabled true
 
-# -- JWT secret used by client as a configMap. Change this value.
 jwt:
 
-# -- Ingress resource for the HTTP API
 ingress:
   enabled: true
-  # -- Annotations for Ingress
   annotations:
     kubernetes.io/ingress.class: traefik
     cert-manager.io/cluster-issuer: letsencrypt-prod
     traefik.ingress.kubernetes.io/router.middlewares: xdai-authentication@kubernetescrd
-  # -- Ingress host
   hosts:
     - host: xdainode.provisioning.circles.garden
       paths:
       - path: /
         pathType: Prefix
       pathType: Prefix
-  # -- Ingress TLS
   tls:
    - secretName: tls-xdainode
      hosts:


### PR DESCRIPTION
graphnode installation was failing because of the upgrade in the nethermind nodes which was failing because of this issue https://github.com/sigp/lighthouse/issues/4490, which has been fixed by removing the flag realted to enr 

Closes #110 